### PR TITLE
Change css layout to make tract list, tract details, and table scrollable

### DIFF
--- a/client/css/dat-gui-afq.css
+++ b/client/css/dat-gui-afq.css
@@ -6,3 +6,7 @@
   font: 13px;
   font-family: "Arial", "Helvetica", sans-serif;
 } 
+
+.dg.main.a {
+  margin-bottom: 20px;
+}

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -9,6 +9,7 @@
 #body {
   font-family: "Arial", "Helvetica", sans-serif;
   color:#666;
+  background: #d9d9d9;
   /* Get rid of accidental text selection on drag */
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none;   /* Chrome/Safari/Opera */
@@ -24,6 +25,7 @@
   justify-content: center;
   align-items: center;
   background-color: #404040;
+  margin-bottom: 10px;
 }
 
 h1 {
@@ -34,70 +36,91 @@ h2 {
   text-align: center;
 }
 
-#title{
-  float:left;
-  height:40px;
-  display:flex;
-  justify-content: left;
-  align-items: center;
-}
-#statcontent{
-  float:left;
-  position:fixed;
-  top: 15;
-}
-#statcontent.sticky {
-  position: fixed;
-  top: 15;
-}
-#tractlist{
-  text-align: left;
-}
-#threeDbrain{
-}
-#tractdetails{
-  overflow: auto;
-  float: left;
+.title{
+  /* height: 40px; */
+  display: flex;
+  justify-content: center;
   align-items: center;
 }
 
-#table{
-  align: center;
+#statcontent{
+  float: left;
+  position: fixed;
+  top: 15;
 }
+
+#statcontent.sticky {
+  top: 15;
+}
+
 .focus text{
   font-size:11px;
 }
 
-.col-1 {width: 8.33%;}
-.col-2 {width: 16.66%;}
-.col-3 {width: 25%;}
-.col-4 {width: 33.33%;}
-.col-4#tractlist {
-  overflow-y: auto;
-  height: 560px;
+#container-list-3d-table {
+  width: 66.66%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }
-.col-5 {width: 40%;}
-.col-5#tractdetails {
-  overflow-y: auto;
-  height: 790px;
-}
-.col-6 {width: 50%;}
-.col-7 {width: 58.33%;}
-.col-8 {width: 66.66%;}
-.col-9 {width: 75%;}
-.col-10 {width: 83.33%;}
-.col-11 {width: 91.66%;}
-.col-12 {width: 100%;}
-.col-12#table {
-  overflow-y: auto;
-  height: 500px;
+#container-plots {width: 33.34%;}
+
+/* Stuff within container-list-3d-table */
+#tractlist-with-title {width: 25%;}
+#threejsbrain-with-title {width: 75%;}
+#table-with-title {width: 100%}
+
+#tractlist {
+  /* Set a height restriction for the tract list. We can use a
+   * ridiculously small number here because flexbox will grow
+   * this item to match the height of the 3D window. We only
+   * need the height to be less than that of the 3D window. */
+  height: 1px;
+  text-align: left;
 }
 
-[class*="col-"] {
-  float: left;
+#tractdetails {
+  height: 1px;
+  text-align: center;
+}
+
+#table {
+  height: 300px;
+  align: center;
+}
+
+.title-and-content {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
+.content {
+  flex-grow: 1;
+  border-radius: 15px;
   padding: 15px;
+  background: #ffffff;
+  margin-bottom: 10px;
 }
 
+#threejsbrain {
+  border-radius: 15px;
+}
+
+.scrollable {
+  overflow-y: auto;
+  overflow-x: auto;
+}
+
+.app {
+  display: flex;
+  align-items: stretch;
+}
+
+.app-element{
+  display: flex;
+  align-items: stretch;
+}
 
 #selectAllBox {
   font-weight: bold;
@@ -129,15 +152,14 @@ label:hover, label:active, input:hover+label, input:active+label {
     background:#ffffcc;
 }
 
-
 .moveGUI {
   padding: 0px;
 }
 
 .row::after {
-    content: "";
-    clear: both;
-    display: block;
+  content: "";
+  clear: both;
+  display: block;
 }
 
 .line {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -40,7 +40,7 @@ h2 {
   /* height: 40px; */
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: baseline;
 }
 
 #statcontent{
@@ -57,17 +57,40 @@ h2 {
   font-size:11px;
 }
 
+.app {
+  display: flex;
+  align-items: stretch;
+}
+
+.app-element{
+  display: flex;
+  align-items: stretch;
+  box-sizing: border-box;
+}
+
 #container-list-3d-table {
-  width: 66.66%;
+  width: 800px;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 }
-#container-plots {width: 33.34%;}
+
+#container-plots {
+  width: 33.34%;
+  flex-grow: 1;
+}
 
 /* Stuff within container-list-3d-table */
-#tractlist-with-title {width: 25%;}
-#threejsbrain-with-title {width: 75%;}
+#tractlist-with-title {width: 240px;}
+#threejsbrain-with-title {
+  width: 300px;
+  flex-grow: 1;
+}
+#gui-container {
+  display: flex;
+  justify-content: flex-end;
+  min-height: 20px;
+}
 #table-with-title {width: 100%}
 
 #tractlist {
@@ -97,29 +120,19 @@ h2 {
 
 .content {
   flex-grow: 1;
-  border-radius: 15px;
+  border-radius: 10px;
   padding: 15px;
   background: #ffffff;
   margin-bottom: 10px;
 }
 
 #threejsbrain {
-  border-radius: 15px;
+  cursor: pointer;
 }
 
 .scrollable {
   overflow-y: auto;
   overflow-x: auto;
-}
-
-.app {
-  display: flex;
-  align-items: stretch;
-}
-
-.app-element{
-  display: flex;
-  align-items: stretch;
 }
 
 #selectAllBox {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -73,11 +73,18 @@ h2 {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  border-right: dashed;
+  border-width: 1px;
+  border-color: #404040
 }
 
-#container-plots {
-  width: 400px;
-  flex-grow: 1;
+#container-list-3d {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  border-bottom: dashed;
+  border-width: 1px;
+  border-color: #404040
 }
 
 /* Stuff within container-list-3d-table */
@@ -91,6 +98,12 @@ h2 {
   justify-content: flex-end;
 }
 #table-with-title {width: 100%}
+
+
+#container-plots {
+  width: 400px;
+  flex-grow: 1;
+}
 
 #tractlist {
   /* Set a height restriction for the tract list. We can use a

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -38,6 +38,7 @@ h2 {
 
 .title{
   /* height: 40px; */
+  flex: 0 0 auto;
   display: flex;
   justify-content: center;
   align-items: baseline;
@@ -68,18 +69,37 @@ h2 {
   box-sizing: border-box;
 }
 
+.title-and-content {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: stretch;
+}
+
+.content {
+  flex-grow: 1;
+  border-radius: 10px;
+  padding: 15px;
+  background: #ffffff;
+  margin-bottom: 10px;
+}
+
+.scrollable {
+  overflow-y: auto;
+  overflow-x: auto;
+}
+
 #container-list-3d-table {
   width: 800px;
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
   border-right: dashed;
   border-width: 1px;
   border-color: #404040
 }
 
 #container-list-3d {
-  width: 100%;
   display: flex;
   flex-direction: row;
   border-bottom: dashed;
@@ -89,20 +109,48 @@ h2 {
 
 /* Stuff within container-list-3d-table */
 #tractlist-with-title {width: 240px;}
+
 #threejsbrain-with-title {
-  width: 300px;
-  flex-grow: 1;
+  flex: 1 1 auto;
 }
+
+#three-and-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+#threejsbrain {
+  display: flex;
+  flex-direction: column;
+  align-items: strecth;
+  /* overflow: auto; */
+
+  flex-grow: 1;
+  flex-shrink: 1;
+
+  width: 100%;
+  min-width: 300px;
+  min-height: 300px;
+}
+
+#threejsbrain > canvas {
+  flex-grow: 1;
+  flex-shrink: 1;
+  align-self: stretch;
+  min-width: 300px;
+  min-height: 300px;
+  cursor: pointer;
+}
+
 #gui-container {
   display: flex;
   justify-content: flex-end;
 }
-#table-with-title {width: 100%}
-
 
 #container-plots {
   width: 400px;
-  flex-grow: 1;
+  flex: 1 1 auto;
 }
 
 #tractlist {
@@ -122,29 +170,6 @@ h2 {
 #table {
   height: 300px;
   align: center;
-}
-
-.title-and-content {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-}
-
-.content {
-  flex-grow: 1;
-  border-radius: 10px;
-  padding: 15px;
-  background: #ffffff;
-  margin-bottom: 10px;
-}
-
-#threejsbrain {
-  cursor: pointer;
-}
-
-.scrollable {
-  overflow-y: auto;
-  overflow-x: auto;
 }
 
 #selectAllBox {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -56,8 +56,8 @@ h2 {
 #threeDbrain{
 }
 #tractdetails{
-  overflow:auto;
-  float:right;
+  overflow: auto;
+  float: left;
   align-items: center;
 }
 
@@ -72,7 +72,15 @@ h2 {
 .col-2 {width: 16.66%;}
 .col-3 {width: 25%;}
 .col-4 {width: 33.33%;}
-.col-5 {width: 41.66%;}
+.col-4#tractlist {
+  overflow-y: auto;
+  height: 560px;
+}
+.col-5 {width: 40%;}
+.col-5#tractdetails {
+  overflow-y: auto;
+  height: 790px;
+}
 .col-6 {width: 50%;}
 .col-7 {width: 58.33%;}
 .col-8 {width: 66.66%;}
@@ -80,12 +88,16 @@ h2 {
 .col-10 {width: 83.33%;}
 .col-11 {width: 91.66%;}
 .col-12 {width: 100%;}
+.col-12#table {
+  overflow-y: auto;
+  height: 500px;
+}
 
 [class*="col-"] {
-    float: left;
-    padding: 15px;
-
+  float: left;
+  padding: 15px;
 }
+
 
 #selectAllBox {
   font-weight: bold;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -6,6 +6,11 @@
     /*border: 0;*/
 }
 
+.w3-container {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
 #body {
   font-family: "Arial", "Helvetica", sans-serif;
   color: #404040;
@@ -123,7 +128,7 @@ h2 {
 #threejsbrain {
   display: flex;
   flex-direction: column;
-  align-items: strecth;
+  align-items: stretch;
   /* overflow: auto; */
 
   flex-grow: 1;
@@ -143,7 +148,7 @@ h2 {
   cursor: pointer;
 }
 
-#gui-container {
+.gui-container {
   display: flex;
   justify-content: flex-end;
 }
@@ -151,6 +156,12 @@ h2 {
 #container-plots {
   width: 400px;
   flex: 1 1 auto;
+}
+
+#plots-and-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 #tractlist {
@@ -165,6 +176,8 @@ h2 {
 #tractdetails {
   height: 1px;
   text-align: center;
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
 #table {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -8,7 +8,7 @@
 
 #body {
   font-family: "Arial", "Helvetica", sans-serif;
-  color:#666;
+  color: #404040;
   background: #d9d9d9;
   /* Get rid of accidental text selection on drag */
     -webkit-touch-callout: none; /* iOS Safari */
@@ -76,7 +76,7 @@ h2 {
 }
 
 #container-plots {
-  width: 33.34%;
+  width: 400px;
   flex-grow: 1;
 }
 
@@ -89,7 +89,6 @@ h2 {
 #gui-container {
   display: flex;
   justify-content: flex-end;
-  min-height: 20px;
 }
 #table-with-title {width: 100%}
 
@@ -163,10 +162,6 @@ label, input[type=checkbox] {
 
 label:hover, label:active, input:hover+label, input:active+label {
     background:#ffffcc;
-}
-
-.moveGUI {
-  padding: 0px;
 }
 
 .row::after {

--- a/client/index.html
+++ b/client/index.html
@@ -46,8 +46,8 @@
           <div class="w3-container title-and-content"
                id="threejsbrain-with-title">
             <div id="subject-title" class="title"><h2>SUBJECT ID</h2></div>
-            <div id="three-and-controls" class="content scrollable">
-                <div id="threejsbrain"></div>
+            <div id="three-and-controls" class="content">
+                <div id="threejsbrain" class="canvasloader-container"></div>
                 <div id="gui-container"></div>
             </div>
           </div>
@@ -83,6 +83,7 @@
     <script type="text/javascript" src="js/resizing.js"></script>
     <script type="text/javascript" src="js/dat.gui.min.js"></script>
     <link type="text/css" rel="stylesheet" href="css/dat-gui-afq.css">
+    <script type="text/javascript" src="http://heartcode-canvasloader.googlecode.com/files/heartcode-canvasloader-min-0.9.1.js"></script>
 
     <!--custom JS code -->
 
@@ -92,6 +93,7 @@
     <script type="text/javascript" src="js/OBJLoader.js"></script>
     
     <script type="text/javascript" src="js/tract-details.js"></script>
+    <script type="text/javascript" src="js/canvas-loader.js"></script>
     <script type="text/javascript" src="js/3d-brain.js"></script>
     <script type="text/javascript" src="js/sortable-table.js"></script>
 

--- a/client/index.html
+++ b/client/index.html
@@ -8,11 +8,11 @@
 
     <!-- FONT
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+    <link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Raleway:400,300,600">
 
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <link rel="stylesheet" href="http://www.w3schools.com/lib/w3.css">
+    <link type="text/css" rel="stylesheet" href="http://www.w3schools.com/lib/w3.css">
     <link type="text/css" rel="stylesheet" href="css/style.css">
 
 </head>
@@ -27,7 +27,7 @@
       <div class="app-element" id="container-list-3d-table">
           <div class="w3-container title-and-content"
                id="tractlist-with-title">
-            <div id="list-title" class="title"><h2>FIBER BUNDLES</h2></div>
+            <div id="list-title" class="title"><h2>BUNDLES</h2></div>
             <div class="content scrollable" id="tractlist">
               <div id="selectAllBox">
                 <input type="checkbox" id="selectAllTracts">
@@ -41,7 +41,7 @@
             <div id="subject-title" class="title"><h2>SUBJECT ID</h2></div>
             <div id="three-and-controls" class="content scrollable">
                 <div id="threejsbrain"></div>
-                <div class="moveGUI"></div>
+                <div id="gui-container"></div>
             </div>
           </div>
 
@@ -53,7 +53,7 @@
       </div>
       <div class="w3-container app-element title-and-content"
            id="container-plots">
-        <div id="plots-title" class="title"><h2>FIBER BUNDLE DETAILS</h2></div>
+        <div id="plots-title" class="title"><h2>BUNDLE DETAILS</h2></div>
         <div id="plots-and-controls" class="content scrollable">
           <div id="tractdetails"></div>
           <div class="plotsGUI"></div>
@@ -63,23 +63,23 @@
 
     <!-- JS Libraries -->
     <script src="//d3js.org/queue.v1.min.js"></script>
-    <script src="js/stats.min.js"></script>
-    <script src="js/three.min.js"></script>
+    <script type="text/javascript" src="js/stats.min.js"></script>
+    <script type="text/javascript" src="js/three.min.js"></script>
     <script src="//d3js.org/d3.v3.min.js"></script>
-    <script src="js/jquery-2.2.3.js"></script>
+    <script type="text/javascript" src="js/jquery-2.2.3.js"></script>
     <script type="text/javascript" src="js/dat.gui.min.js"></script>
     <link type="text/css" rel="stylesheet" href="css/dat-gui-afq.css">
 
     <!--custom JS code -->
 
-    <script src="js/Projector.js"></script>
-    <script src="js/threex.domevent.js"></script>
-    <script src="js/OrbitControls.js"></script>
-    <script src="js/OBJLoader.js"></script>
+    <script type="text/javascript" src="js/Projector.js"></script>
+    <script type="text/javascript" src="js/threex.domevent.js"></script>
+    <script type="text/javascript" src="js/OrbitControls.js"></script>
+    <script type="text/javascript" src="js/OBJLoader.js"></script>
     
-    <script src="js/tract-details.js"></script>
-    <script src="js/3d-brain.js"></script>
-    <script src="js/sortable-table.js"></script>
+    <script type="text/javascript" src="js/tract-details.js"></script>
+    <script type="text/javascript" src="js/3d-brain.js"></script>
+    <script type="text/javascript" src="js/sortable-table.js"></script>
 
 </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -14,10 +14,10 @@
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <link type="text/css" rel="stylesheet"
-          href="http://www.w3schools.com/lib/w3.css">
-    <link type="text/css" rel="stylesheet"
           href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link type="text/css" rel="stylesheet" href="css/style.css">
+    <link type="text/css" rel="stylesheet"
+          href="http://www.w3schools.com/lib/w3.css">
 
 </head>
 
@@ -48,7 +48,7 @@
             <div id="subject-title" class="title"><h2>SUBJECT ID</h2></div>
             <div id="three-and-controls" class="content">
                 <div id="threejsbrain" class="canvasloader-container"></div>
-                <div id="gui-container"></div>
+                <div id="three-gui-container" class="gui-container"></div>
             </div>
           </div>
 
@@ -64,9 +64,9 @@
       <div class="w3-container app-element title-and-content"
            id="container-plots">
         <div id="plots-title" class="title"><h2>BUNDLE DETAILS</h2></div>
-        <div id="plots-and-controls" class="content scrollable">
-          <div id="tractdetails"></div>
-          <div class="plotsGUI"></div>
+        <div id="plots-and-controls" class="content">
+          <div id="tractdetails" class="scrollable"></div>
+          <div id="plots-gui-container" class="gui-container"></div>
         </div>
       </div>
     </div>

--- a/client/index.html
+++ b/client/index.html
@@ -8,11 +8,15 @@
 
     <!-- FONT
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Raleway:400,300,600">
+    <link type="text/css" rel="stylesheet"
+          href="//fonts.googleapis.com/css?family=Raleway:400,300,600">
 
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <link type="text/css" rel="stylesheet" href="http://www.w3schools.com/lib/w3.css">
+    <link type="text/css" rel="stylesheet"
+          href="http://www.w3schools.com/lib/w3.css">
+    <link type="text/css" rel="stylesheet"
+          href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link type="text/css" rel="stylesheet" href="css/style.css">
 
 </head>
@@ -24,7 +28,7 @@
     </div>
 
     <div class="app" id="app">
-      <div class="app-element" id="container-list-3d-table">
+      <div class="app-element resizable" id="container-list-3d-table">
           <div class="w3-container title-and-content"
                id="tractlist-with-title">
             <div id="list-title" class="title"><h2>BUNDLES</h2></div>
@@ -62,11 +66,15 @@
     </div>
 
     <!-- JS Libraries -->
-    <script src="//d3js.org/queue.v1.min.js"></script>
+    <script type="text/javascript" src="//d3js.org/queue.v1.min.js"></script>
     <script type="text/javascript" src="js/stats.min.js"></script>
     <script type="text/javascript" src="js/three.min.js"></script>
-    <script src="//d3js.org/d3.v3.min.js"></script>
-    <script type="text/javascript" src="js/jquery-2.2.3.js"></script>
+    <script type="text/javascript" src="//d3js.org/d3.v3.min.js"></script>
+    <script type="text/javascript"
+            src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script type="text/javascript"
+            src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script type="text/javascript" src="js/resizing.js"></script>
     <script type="text/javascript" src="js/dat.gui.min.js"></script>
     <link type="text/css" rel="stylesheet" href="css/dat-gui-afq.css">
 

--- a/client/index.html
+++ b/client/index.html
@@ -44,7 +44,6 @@
     <div class="col-5" id="tractdetails"></div>
 >>>>>>> master-->
 
-
     </div>
 
     <!-- JS Libraries -->

--- a/client/index.html
+++ b/client/index.html
@@ -12,6 +12,7 @@
 
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+    <link rel="stylesheet" href="http://www.w3schools.com/lib/w3.css">
     <link type="text/css" rel="stylesheet" href="css/style.css">
 
 </head>
@@ -21,29 +22,43 @@
     <div id="header">
         <h1 style="color:white;">AFQ Browser</h1>
     </div>
-    <div class="titlebar">
-        <div id="title" class="col-2"><h2>FIBER BUNDLES</h2></div>
-        <div id="title" class="col-5"><h2></h2></div>
-        <div id="title" class="col-5"><h2>FIBER BUNDLE DETAILS</h2></div>
-    </div>
-    <div class="col-7">
-        <div class="col-4" id="tractlist">
-            <div id="selectAllBox"> <input type="checkbox" id="selectAllTracts"><br> <label for="selectAllTracts">All Tracts</label></div>
-        </div>
-        <div class="col-8">
-            <div class="col-12" id="threejsbrain"></div>
-            <div class="moveGUI"></div>
-        </div>
 
-        <div id="table" class="col-12"><h2>SUBJECT METADATA</h2><br></div>
-    </div>
-<!--<<<<<< HEAD-->
-    <div class="col-5" id="tractdetails"></div>
-    <div class="plotsGUI"></div>
-<!--=======
-    <div class="col-5" id="tractdetails"></div>
->>>>>>> master-->
+    <div class="app" id="app">
+      <div class="app-element" id="container-list-3d-table">
+          <div class="w3-container title-and-content"
+               id="tractlist-with-title">
+            <div id="list-title" class="title"><h2>FIBER BUNDLES</h2></div>
+            <div class="content scrollable" id="tractlist">
+              <div id="selectAllBox">
+                <input type="checkbox" id="selectAllTracts">
+                <label for="selectAllTracts">All Tracts</label>
+              </div>
+            </div>
+          </div>
 
+          <div class="w3-container title-and-content"
+               id="threejsbrain-with-title">
+            <div id="subject-title" class="title"><h2>SUBJECT ID</h2></div>
+            <div id="three-and-controls" class="content scrollable">
+                <div id="threejsbrain"></div>
+                <div class="moveGUI"></div>
+            </div>
+          </div>
+
+          <div class="w3-container title-and-content"
+               id="table-with-title">
+            <div id="table-title" class="title"><h2>SUBJECT METADATA</h2><br></div>
+            <div id="table" class="content scrollable"></div>
+          </div>
+      </div>
+      <div class="w3-container app-element title-and-content"
+           id="container-plots">
+        <div id="plots-title" class="title"><h2>FIBER BUNDLE DETAILS</h2></div>
+        <div id="plots-and-controls" class="content scrollable">
+          <div id="tractdetails"></div>
+          <div class="plotsGUI"></div>
+        </div>
+      </div>
     </div>
 
     <!-- JS Libraries -->

--- a/client/index.html
+++ b/client/index.html
@@ -28,7 +28,10 @@
     </div>
 
     <div class="app" id="app">
-      <div class="app-element resizable" id="container-list-3d-table">
+      <div class="app-element ew-resize" id="container-list-3d-table">
+
+        <div class="app-element ns-resize" id="container-list-3d">
+
           <div class="w3-container title-and-content"
                id="tractlist-with-title">
             <div id="list-title" class="title"><h2>BUNDLES</h2></div>
@@ -49,11 +52,14 @@
             </div>
           </div>
 
-          <div class="w3-container title-and-content"
-               id="table-with-title">
-            <div id="table-title" class="title"><h2>SUBJECT METADATA</h2><br></div>
-            <div id="table" class="content scrollable"></div>
-          </div>
+        </div>
+
+        <div class="w3-container title-and-content"
+             id="table-with-title">
+          <div id="table-title" class="title"><h2>SUBJECT METADATA</h2><br></div>
+          <div id="table" class="content scrollable"></div>
+        </div>
+
       </div>
       <div class="w3-container app-element title-and-content"
            id="container-plots">

--- a/client/js/3d-brain.js
+++ b/client/js/3d-brain.js
@@ -31,7 +31,7 @@ var colorGroups = new THREE.Object3D();
 var greyGroups = new THREE.Object3D();
 
 // Set initial opacitites here
-var initLHOpacity = 0.0;
+var initLHOpacity = 0.01;
 var initRHOpacity = 0.3;
 var initFiberOpacity = 0.1;
 var initColorOpacity = 0.75;
@@ -59,9 +59,6 @@ var gui = new dat.GUI({
 
 var controlBox = new guiConfigObj();
 
-// gui.domElement.id = 'gui';
-var guiContainer = $('.moveGUI').append($(gui.domElement));
-
 var greyLineMaterial = new THREE.LineBasicMaterial({
 	opacity: initFiberOpacity,
 	linewidth: initFiberLineWidth,
@@ -69,7 +66,7 @@ var greyLineMaterial = new THREE.LineBasicMaterial({
 	depthWrite: true
 });
 
-greyLineMaterial.color.setHex( 0x969696 );
+greyLineMaterial.color.setHex( 0x444444 );
 
 var colorLineMaterial = new THREE.LineBasicMaterial({
 	opacity: 0.0,
@@ -116,7 +113,7 @@ function init() {
 
     // camera = new THREE.PerspectiveCamera(45, WIDTH / HEIGHT, 1, 2000);
     camera = new THREE.PerspectiveCamera( 45, Width / sizeY, 1, 2000 );
-    camera.position.x = -20;
+    camera.position.x = -15;
 	camera.up.set(0, 0, 1);
 
     // scene
@@ -139,7 +136,7 @@ function init() {
     };
 
     // renderer
-    renderer = new THREE.WebGLRenderer();
+    renderer = new THREE.WebGLRenderer({ alpha: true });
 
     renderer.setSize(Width, sizeY);
     container.appendChild(renderer.domElement);
@@ -169,14 +166,19 @@ function init() {
             }
         });
 		lh.translateX(-0.05);
-        lh.material.opacity = initLHOpacity;
 		rh.translateX( 0.05);
+
+        lh.material.opacity = initLHOpacity;
         rh.material.opacity = initRHOpacity;
+
+		lh.material.color.setHex( 0xe8e3d3 );
+		rh.material.color.setHex( 0xe8e3d3 );
+
         scene.add(object);
     });
 
 	var lhOpacityController = gui.add(controlBox, 'lhOpacity')
-		.min(0).max(1).name('Left Hemi Opacity');
+		.min(0).max(1).step(0.01).name('Left Hemi Opacity');
 
 	lhOpacityController.onChange( function(value) {
 		lh.traverse(function (child) {
@@ -187,7 +189,7 @@ function init() {
 	});
 
 	var rhOpacityController = gui.add(controlBox, 'rhOpacity')
-		.min(0).max(1).name('Right Hemi Opacity');
+		.min(0).max(1).step(0.01).name('Right Hemi Opacity');
 
 	rhOpacityController.onChange( function(value) {
 		rh.traverse(function (child) {
@@ -220,6 +222,8 @@ function init() {
 		console.log(value);
 	});
 
+	var guiContainer = document.getElementById('gui-container');
+	guiContainer.appendChild(gui.domElement);
 	gui.close();
 
     // contain all bundles in this Group object

--- a/client/js/3d-brain.js
+++ b/client/js/3d-brain.js
@@ -216,7 +216,7 @@ function init() {
 		console.log(value);
 	});
 
-	var guiContainer = document.getElementById('gui-container');
+	var guiContainer = document.getElementById('three-gui-container');
 	guiContainer.appendChild(gui.domElement);
 	gui.close();
 

--- a/client/js/3d-brain.js
+++ b/client/js/3d-brain.js
@@ -17,8 +17,6 @@ h = 350 - m.top - m.bottom;
 
 // =========== three js part
 
-var container;
-
 var camera, scene, renderer;
 var directionalLight;
 
@@ -53,7 +51,7 @@ var guiConfigObj = function () {
 
 var gui = new dat.GUI({
 	autoplace: false,
-	width: 350,
+	width: 250,
 	scrollable: false
 });
 
@@ -94,25 +92,21 @@ var faPlotLength = 100;
 var showStats = false;
 var stats;
 
+// We put the renderer inside a div with id #threejsbrain
+var container;
+
 if (showStats) {
 	stats = new Stats();
 	container.appendChild( stats.dom );
 }
 
 function init() {
+	container = document.getElementById("threejsbrain");
 
-    // We put the container inside a div with id #threejsbrain
-    var puthere = document.getElementById("threejsbrain");
-    container = document.createElement('div');
-    puthere.appendChild(container);
+    var width = container.clientWidth;
+	var height = container.clientHeight;
 
-    // var WIDTH = window.innerWidth,
-        // HEIGHT = window.innerHeight;
-
-    Width = container.clientWidth;
-
-    // camera = new THREE.PerspectiveCamera(45, WIDTH / HEIGHT, 1, 2000);
-    camera = new THREE.PerspectiveCamera( 45, Width / sizeY, 1, 2000 );
+    camera = new THREE.PerspectiveCamera( 45, width / height, 1, 2000 );
     camera.position.x = -15;
 	camera.up.set(0, 0, 1);
 
@@ -138,7 +132,7 @@ function init() {
     // renderer
     renderer = new THREE.WebGLRenderer({ alpha: true });
 
-    renderer.setSize(Width, sizeY);
+    renderer.setSize(width, height);
     container.appendChild(renderer.domElement);
 
     // dom event
@@ -390,12 +384,17 @@ function init() {
 
 // Resize the three.js window on full window resize.
 function onWindowResize() {
-    var Width = container.clientWidth;
+    var width = container.clientWidth;
+	var height = container.clientHeight;
 
-    camera.aspect = Width / sizeY;
+    camera.aspect = width / height;
     camera.updateProjectionMatrix();
 
-    renderer.setSize(Width, sizeY);
+    renderer.setSize(width, height);
+	console.log("(cw, ch, rw, rh) = ("
+			+ width + ", " + height + ", "
+			+ renderer.domElement.clientWidth + ", "
+			+ renderer.domElement.clientHeight + ")");
 }
 
 function animate() {

--- a/client/js/resizing.js
+++ b/client/js/resizing.js
@@ -1,0 +1,9 @@
+$('.resizable')
+	.resizable({
+		handles: "e",
+		create: function( event, ui ) {
+            // Prefers an another cursor with two arrows
+			// Choose between "col-resize" and "ew-resize"
+            $(".ui-resizable-e").css("cursor","col-resize");
+        }
+	});

--- a/client/js/resizing.js
+++ b/client/js/resizing.js
@@ -5,7 +5,10 @@ $('.ew-resize')
             // Prefers an another cursor with two arrows
 			// Choose between "col-resize" and "ew-resize"
             $(".ui-resizable-e").css("cursor","col-resize");
-        }
+        },
+		resize: function( event, ui) {
+			onWindowResize();
+		}
 	});
 
 $('.ns-resize')
@@ -15,5 +18,8 @@ $('.ns-resize')
             // Prefers an another cursor with two arrows
 			// Choose between "col-resize" and "ns-resize"
             $(".ui-resizable-s").css("cursor","row-resize");
-        }
+        },
+		resize: function( event, ui) {
+			onWindowResize();
+		}
 	});

--- a/client/js/resizing.js
+++ b/client/js/resizing.js
@@ -1,9 +1,19 @@
-$('.resizable')
+$('.ew-resize')
 	.resizable({
 		handles: "e",
 		create: function( event, ui ) {
             // Prefers an another cursor with two arrows
 			// Choose between "col-resize" and "ew-resize"
             $(".ui-resizable-e").css("cursor","col-resize");
+        }
+	});
+
+$('.ns-resize')
+	.resizable({
+		handles: "s",
+		create: function( event, ui ) {
+            // Prefers an another cursor with two arrows
+			// Choose between "col-resize" and "ns-resize"
+            $(".ui-resizable-s").css("cursor","row-resize");
         }
 	});

--- a/client/js/tract-details.js
+++ b/client/js/tract-details.js
@@ -100,16 +100,14 @@ var plotsGuiConfigObj = function () {
 
 var plotsGui = new dat.GUI({
     autoplace: false,
-    width: 350,
+    width: 250,
     scrollable: false
 });
 
 var plotsControlBox = new plotsGuiConfigObj();
 
-// gui.domElement.id = 'gui';
-var plotsGuiContainer = $('.plotsGUI').append($(plotsGui.domElement));
-
-
+var plotsGuiContainer = document.getElementById('plots-gui-container');
+plotsGuiContainer.appendChild(plotsGui.domElement);
 
 var brushController = plotsGui.add(plotsControlBox, 'brushTract')
     .name('Brushable Tracts');


### PR DESCRIPTION
Addresses issues #33 and #36. This PR makes the tract details plots scrollable as well as the tract list on the left and the subject metadata table at the bottom.

Pros:
- Things fit better now
- The viewer can see any tract detail plot while also keeping the 3D brain in view

Cons:
- The tract list is truncated such that the viewer could be misled into thinking there are fewer tracts than there really are.
- There are now 5 different responses to scrolling depending on where the user's cursor is located (3D zoom, whole page scrolling, and scrolling in 3 different sub-panels). It could be easier to get lost with this effect.

@arokem, @jyeatman, @anotherjoshsmith What do you think?
