### PR TITLE
Replace panel title

### DIFF
--- a/afqbrowser/site/client/index.html
+++ b/afqbrowser/site/client/index.html
@@ -49,7 +49,7 @@
 
           <div id="threejsbrain-with-title"
               class="w3-container title-and-content panel-right">
-            <div id="subject-title" class="title"><h2>SUBJECT ID</h2></div>
+            <div id="subject-title" class="title"><h2>ANATOMY</h2></div>
             <div id="three-and-controls" class="content">
               <div id="threejsbrain" class="canvasloader-container"></div>
               <div id="three-gui-container" class="gui-container"></div>


### PR DESCRIPTION
Tiny detail: it looks a bit like a mockup with the previous title. When we figure out how to slot the subject anatomy in here, we can reinstate this, with the subject ID.