### PR TITLE
Standard error shading and svg cleanup

### DIFF
--- a/afqbrowser/site/client/css/style.css
+++ b/afqbrowser/site/client/css/style.css
@@ -83,7 +83,7 @@ h2 {
   display: flex;
   flex-direction: row;
   overflow: hidden;
-  
+
   width: 100%;
 }
 
@@ -156,9 +156,9 @@ h2 {
 #threejsbrain-with-title {
   flex: 1 1 auto;
   /* There was an issue where this div would not shrink when the user
-   * shortened the main left panel. This next line fixes that issue. It 
-   * makes absolutely no sense to me why this works. But it works.      
-   * I hereby bequeash this bug, this comment, and this hacky fix to    
+   * shortened the main left panel. This next line fixes that issue. It
+   * makes absolutely no sense to me why this works. But it works.
+   * I hereby bequeash this bug, this comment, and this hacky fix to
    * the flexbox ninja brave enough to give it a legitimate solution. */
   width: 30%;
 }
@@ -272,6 +272,11 @@ label:hover, label:active, input:hover+label, input:active+label {
   fill: none;
   stroke-linejoin: round;
   stroke-linecap:round;
+}
+
+.area {
+    fill: #AFBABF;
+    stroke-width: 0;
 }
 
 .tracts {

--- a/afqbrowser/site/client/css/style.css
+++ b/afqbrowser/site/client/css/style.css
@@ -366,6 +366,11 @@ fill: #404040;
     font-size: 14px;
 }
 
+.area {
+  stroke: none;
+  fill: #AFBABF;
+}
+
 .x.axis path {
     display: none;
 }

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -131,6 +131,11 @@ afqb.plots.line = d3.svg.line()
         }
     });
 
+afqb.plots.area = d3.svg.area()
+		.x(function(d) { return afqb.plots.x(+d.key) })
+		.y0(function(d) { return afqb.plots.y(+d.values.mean - +d.values.stderr*3); })
+		.y1(function(d) { return afqb.plots.y(+d.values.mean + +d.values.stderr*3); });
+
 afqb.plots.bundleBrush = {};
 
 function buildPlotGui(error, data) {
@@ -318,6 +323,11 @@ function ready(error, data) {
 		})
         .attr("class", "tracts means")
         .attr("id", "mean0");
+
+	  meanLines.append("path")
+			  .attr("class", "area")
+				.attr("d", function(d) {return afqb.plots.area(d); })
+				.style("opacity", 0.4);
 
     meanLines.append("path")
         .attr("class", "line")

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -1,7 +1,7 @@
 //tractlist js
 
 afqb.plots = {};
-afqb.plots.m = {top: 20, right: 10, bottom: 10, left: 20};
+afqb.plots.m = {top: 20, right: 10, bottom: 10, left: 25};
 afqb.plots.w = 400 - afqb.plots.m.left - afqb.plots.m.right,
 afqb.plots.h = 350 - afqb.plots.m.top - afqb.plots.m.bottom;
 afqb.plots.axisOffset = {bottom: 40};
@@ -90,7 +90,7 @@ function buildTractCheckboxes(error, data) {
 }
 
 afqb.plots.x = d3.scale.linear()
-    .range([afqb.plots.m.left + 20, afqb.plots.w + afqb.plots.m.left + 20]);
+    .range([afqb.plots.m.left + 25, afqb.plots.w + afqb.plots.m.left + 20]);
 
 afqb.plots.y = d3.scale.linear()
     .range([afqb.plots.h - afqb.plots.axisOffset.bottom, 0]);
@@ -133,7 +133,6 @@ afqb.plots.line = d3.svg.line()
 
 afqb.plots.area = d3.svg.area()
 		.x(function(d) { return afqb.plots.x(+d.key) })
-		//.y0(function(d) { return afqb.plots.y(+d.values.mean - +d.values.stderr); })
 		.y0(function (d) {
         if (afqb.controls.plotsControlBox.errorType == 'stderr') {
             return afqb.plots.y(+d.values.mean - +d.values.stderr);
@@ -141,7 +140,6 @@ afqb.plots.area = d3.svg.area()
             return afqb.plots.y(+d.values.mean - +d.values.std);
         }
     })
-		//.y1(function(d) { return afqb.plots.y(+d.values.mean + +d.values.stderr); });
 		.y1(function (d) {
 				if (afqb.controls.plotsControlBox.errorType == 'stderr') {
 						return afqb.plots.y(+d.values.mean + +d.values.stderr);
@@ -181,6 +179,16 @@ function buildPlotGui(error, data) {
         .name('Plot Type')
         .onChange(function () {
             d3.csv("data/nodes.csv", updatePlots);
+						// update y label
+						d3.selectAll(".y.label").remove()
+
+						d3.select("#tractdetails").selectAll("svg").append("text")
+						  .attr("text-anchor", "middle")
+						  .attr("transform", "translate("+ (afqb.plots.m.left/2+5) +","+
+									((afqb.plots.h+afqb.plots.m.top)/2)+")rotate(-90)")
+						  .attr("class", "y label")
+						  .style("stroke", "#888888;")
+						  .text(function (d,i) { return afqb.controls.plotsControlBox.plotKey});
         });
 
 		var errorController = plotsGui
@@ -245,17 +253,25 @@ function ready(error, data) {
         .attr("display", "none")
         .append("g")
         .attr("transform", "translate(" + afqb.plots.m.left + "," + afqb.plots.m.top + ")")
-		//y-axis
+				//y-axis
         .append("g")
         .attr("class", "y axis")
         .attr("transform", "translate(" + afqb.plots.m.left + ",0)")
         .call(afqb.plots.yAxis);
 
+		// y axis label
+		trPanels.append("text")
+				.attr("text-anchor", "middle")
+				.attr("transform", "translate("+ (afqb.plots.m.left/2+5) +","+
+							((afqb.plots.h+afqb.plots.m.top)/2)+")rotate(-90)")
+				.attr("class", "y label")
+				.style("stroke", "#888888;")
+				.text(function (d,i) { return afqb.controls.plotsControlBox.plotKey});
+
 		trPanels.append("svg:rect")
         .attr("class", "zoom y box")
         .attr("width", afqb.plots.m.left+20)
         .attr("height", afqb.plots.h - afqb.plots.m.top - afqb.plots.m.bottom)
-        //.attr("transform", "translate(" + afqb.plots.m.left + ",0)")
         .style("visibility", "hidden")
         .attr("pointer-events", "all")
         .call(afqb.plots.yzoom);
@@ -268,7 +284,7 @@ function ready(error, data) {
 
 	trPanels.append("rect")
 		.attr("class", "plot")
-		.attr("width", afqb.plots.w + afqb.plots.m.left + afqb.plots.m.right + 20)
+		.attr("width", afqb.plots.w + afqb.plots.m.left + afqb.plots.m.right + 30)
 		.attr("height", afqb.plots.h + afqb.plots.m.top + afqb.plots.m.bottom + 15)
 		.attr("x", 0)
 		.attr("y", 0)
@@ -276,22 +292,24 @@ function ready(error, data) {
 		.style("fill", "none")
 		.style("stroke-width", 2);
 
-    trPanels.append("text")
-		.attr("x", 350)
-		.attr("y", afqb.plots.h + 25)
+  trPanels.append("text")
 		.attr("class", "plot_text")
+		.attr("text-anchor", "middle")
+		.attr("transform", "translate("+ (afqb.plots.w-afqb.plots.m.left) +","+
+					((afqb.plots.h+afqb.plots.m.bottom+20))+")")
 		.style("text-anchor", "end")
 		.style("stroke", "#888888;")
 		.text("% Distance Along Fiber Bundle");
 
+  // add tract name to top corner
 	trPanels.append("text")
-		.attr("x", afqb.plots.w + 40)
-		.attr("y", afqb.plots.h - 280)
 		.attr("class", "plot_text")
-		.style("text-anchor", "end")
-		.style("stroke", function(d){return afqb.d3colors[d.name-1];} )
-		.style("fill", function(d){return afqb.d3colors[d.name-1];} )
-		.text(function(d) { return afqb.plots.tracts[d.name-1]; });
+		.attr("text-anchor", "end")
+		.attr("transform", "translate("+ (afqb.plots.w + afqb.plots.m.right + 30)
+					+","+(afqb.plots.m.top)+")")
+		.style("stroke", function(d,i){return afqb.d3colors[i];} )
+		.style("fill", function(d,i){return afqb.d3colors[i];} )
+		.text(function(d,i) { return afqb.plots.tracts[i]; });
 
 	// associate tractsline with each subject
     var tractLines = trPanels.selectAll(".tracts")
@@ -504,6 +522,7 @@ function updatePlots(error, data) {
 			.key(function (d) { return d.tractID; })
 			.key(function (d) { return d.nodeID; })
 			.rollup(function (v) {
+				if (afqb.table.splitGroups) {
 				return{
 					mean: d3.mean(v, function (d) {
 					 return +d[afqb.controls.plotsControlBox.plotKey];}),
@@ -513,7 +532,18 @@ function updatePlots(error, data) {
 					std: d3.deviation(v, function (d) {
  					 return +d[afqb.controls.plotsControlBox.plotKey];
  					 })
-			};})
+				 }} else {
+					 return{
+ 						mean: d3.mean(v, function (d) {
+ 						 return +d[afqb.controls.plotsControlBox.plotKey];}),
+ 					  stderr: d3.deviation(v, function (d) {
+ 						 return +d[afqb.controls.plotsControlBox.plotKey];
+ 					   })/Math.sqrt(afqb.plots.tractData[0].values.length),
+ 					  std: d3.deviation(v, function (d) {
+ 						 return +d[afqb.controls.plotsControlBox.plotKey];
+ 					   })
+				 };}
+			 })
 			.entries(data);
 
 		for (iTract = 0; iTract < afqb.plots.tractMean.length; iTract++) {

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -127,7 +127,7 @@ afqb.plots.line = d3.svg.line()
         if (d[afqb.controls.plotsControlBox.plotKey]) {
             return afqb.plots.y(+d[afqb.controls.plotsControlBox.plotKey]);
         } else {
-            return afqb.plots.y(+d.values);
+            return afqb.plots.y(+d.values.mean);
         }
     });
 
@@ -293,15 +293,20 @@ function ready(error, data) {
             }
         });
 
+
+
     // compute mean line
     afqb.plots.tractMean = d3.nest()
         .key(function (d) { return d.tractID; })
         .key(function (d) { return d.nodeID; })
         .rollup(function (v) {
-			return d3.mean(v, function (d) {
-				return +d[afqb.controls.plotsControlBox.plotKey];
-			});
-		})
+			 		return{
+						mean: d3.mean(v, function (d) {
+						 return +d[afqb.controls.plotsControlBox.plotKey];}),
+					  stderr: d3.deviation(v, function (d) {
+						 return +d[afqb.controls.plotsControlBox.plotKey];
+					})/afqb.plots.tractData[0].values.length
+				};})
         .entries(data);
 
     var meanLines = d3.select("#tractdetails").selectAll("svg")
@@ -433,10 +438,13 @@ function updatePlots(error, data) {
 			.key(function (d) { return afqb.table.subGroups[d.subjectID]; })
 			.key(function (d) { return d.nodeID; })
 			.rollup(function (v) {
-				return d3.mean(v, function (d) {
-					return +d[afqb.controls.plotsControlBox.plotKey];
-				});
-			})
+				return{
+					mean: d3.mean(v, function (d) {
+					 return +d[afqb.controls.plotsControlBox.plotKey];}),
+					stderr: d3.deviation(v, function (d) {
+					 return +d[afqb.controls.plotsControlBox.plotKey];
+				})/afqb.plots.tractData[0].values.length
+			};})
 			.entries(data);
 
 		for (iTract = 0; iTract < afqb.plots.tractMean.length; iTract++) {
@@ -458,10 +466,13 @@ function updatePlots(error, data) {
 			.key(function (d) { return d.tractID; })
 			.key(function (d) { return d.nodeID; })
 			.rollup(function (v) {
-				return d3.mean(v, function (d) {
-					return +d[afqb.controls.plotsControlBox.plotKey];
-				});
-			})
+				return{
+					mean: d3.mean(v, function (d) {
+					 return +d[afqb.controls.plotsControlBox.plotKey];}),
+					stderr: d3.deviation(v, function (d) {
+					 return +d[afqb.controls.plotsControlBox.plotKey];
+				})/afqb.plots.tractData[0].values.length
+			};})
 			.entries(data);
 
 		for (iTract = 0; iTract < afqb.plots.tractMean.length; iTract++) {

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -338,8 +338,6 @@ function ready(error, data) {
             }
         });
 
-
-
     // compute mean line
     afqb.plots.tractMean = d3.nest()
         .key(function (d) { return d.tractID; })
@@ -350,7 +348,7 @@ function ready(error, data) {
 						 return +d[afqb.controls.plotsControlBox.plotKey];}),
 					  stderr: d3.deviation(v, function (d) {
 						 return +d[afqb.controls.plotsControlBox.plotKey];
-					   })/Math.sqrt(afqb.plots.tractData[0].values.length),
+					 })/Math.sqrt(v.length),
 					  std: d3.deviation(v, function (d) {
 						 return +d[afqb.controls.plotsControlBox.plotKey];
 					   })
@@ -486,6 +484,7 @@ function updatePlots(error, data) {
 				.entries(data);
 		}
 
+
         afqb.plots.tractMean = d3.nest()
 			.key(function (d) { return d.tractID; })
 			.key(function (d) { return afqb.table.subGroups[d.subjectID]; })
@@ -494,14 +493,15 @@ function updatePlots(error, data) {
 				return{
 					mean: d3.mean(v, function (d) {
 					 return +d[afqb.controls.plotsControlBox.plotKey];}),
-					stderr: d3.deviation(v, function (d) {
-					 return +d[afqb.controls.plotsControlBox.plotKey];
-				 })/Math.sqrt(afqb.table.splitGroups[0].values.length),
+					stderr: d3.deviation(v, function (d,i) {
+					 return +d[afqb.controls.plotsControlBox.plotKey];})/Math.sqrt(v.length),
 					std: d3.deviation(v, function (d) {
 	 				 return +d[afqb.controls.plotsControlBox.plotKey];
 	 				 })
 			};})
 			.entries(data);
+
+
 
 		for (iTract = 0; iTract < afqb.plots.tractMean.length; iTract++) {
 			var index = afqb.plots.tractMean[iTract].values
@@ -518,31 +518,20 @@ function updatePlots(error, data) {
 				.entries(data);
 		}
 
-        afqb.plots.tractMean = d3.nest()
+     afqb.plots.tractMean = d3.nest()
 			.key(function (d) { return d.tractID; })
 			.key(function (d) { return d.nodeID; })
 			.rollup(function (v) {
-				if (afqb.table.splitGroups) {
-				return{
-					mean: d3.mean(v, function (d) {
-					 return +d[afqb.controls.plotsControlBox.plotKey];}),
-					stderr: d3.deviation(v, function (d) {
-					 return +d[afqb.controls.plotsControlBox.plotKey];
-				 })/Math.sqrt(afqb.table.splitGroups[0].values.length),
-					std: d3.deviation(v, function (d) {
- 					 return +d[afqb.controls.plotsControlBox.plotKey];
- 					 })
-				 }} else {
 					 return{
  						mean: d3.mean(v, function (d) {
  						 return +d[afqb.controls.plotsControlBox.plotKey];}),
  					  stderr: d3.deviation(v, function (d) {
  						 return +d[afqb.controls.plotsControlBox.plotKey];
- 					   })/Math.sqrt(afqb.plots.tractData[0].values.length),
+					 })/Math.sqrt(v.length),
  					  std: d3.deviation(v, function (d) {
  						 return +d[afqb.controls.plotsControlBox.plotKey];
  					   })
-				 };}
+				 };
 			 })
 			.entries(data);
 

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -502,7 +502,6 @@ function updatePlots(error, data) {
 			.entries(data);
 
 
-
 		for (iTract = 0; iTract < afqb.plots.tractMean.length; iTract++) {
 			var index = afqb.plots.tractMean[iTract].values
 				.findIndex(item => item.key === "null");
@@ -597,7 +596,7 @@ function updatePlots(error, data) {
 				meanLines.append("path")
 						.attr("class", "area")
 						.attr("d", function(d) {return afqb.plots.area(d.values); })
-						.style("opacity", 0.25);
+						.style("opacity", 0.3);
 
 			meanLines.append("path")
 				.attr("class", "line")

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -133,8 +133,8 @@ afqb.plots.line = d3.svg.line()
 
 afqb.plots.area = d3.svg.area()
 		.x(function(d) { return afqb.plots.x(+d.key) })
-		.y0(function(d) { return afqb.plots.y(+d.values.mean - +d.values.stderr*3); })
-		.y1(function(d) { return afqb.plots.y(+d.values.mean + +d.values.stderr*3); });
+		.y0(function(d) { return afqb.plots.y(+d.values.mean - +d.values.stderr); })
+		.y1(function(d) { return afqb.plots.y(+d.values.mean + +d.values.stderr); });
 
 afqb.plots.bundleBrush = {};
 
@@ -333,7 +333,7 @@ function ready(error, data) {
         .attr("class", "line")
         .attr("d", function(d) {return afqb.plots.line(d); })
         .style("opacity", 0.99)
-        .style("stroke-width", "3.5px");
+        .style("stroke-width", "3px");
 
     function mouseover() {
         if (!afqb.mouse.brushing) {
@@ -544,13 +544,20 @@ function updatePlots(error, data) {
 				.attr("class", "tracts means")
 				.attr("id", function(d) {return "mean" + d.key;});
 
+				meanLines.append("path")
+						.attr("class", "area")
+						.attr("d", function(d) {return afqb.plots.area(d.values); })
+						.style("opacity", 0.25);
+
 			meanLines.append("path")
 				.attr("class", "line")
 				.attr("d", function(d) {return afqb.plots.line(d.values); })
 				.style("opacity", 0.99)
-				.style("stroke-width", "3.5px");
+				.style("stroke-width", "3px");
 	    // set mean colors
-	    d3.select("#tractdetails").selectAll("svg").selectAll(".means")
+	    d3.select("#tractdetails").selectAll("svg").selectAll(".means").select(".area")
+			  .style("fill", function (d, i) { return afqb.table.ramp(i); });
+			d3.select("#tractdetails").selectAll("svg").selectAll(".means").select(".line")
 	      .style("stroke", function (d, i) { return afqb.table.ramp(i); });
 	  } else{
 			// Gray meanLines for unsorted 'Plot Type' change
@@ -564,11 +571,16 @@ function updatePlots(error, data) {
 				.attr("class", "tracts means")
 				.attr("id", "mean0");
 
+				meanLines.append("path")
+					  .attr("class", "area")
+						.attr("d", function(d) {return afqb.plots.area(d); })
+						.style("opacity", 0.25);
+
 			meanLines.append("path")
 				.attr("class", "line")
 				.attr("d", function(d) {return afqb.plots.line(d); })
 				.style("opacity", 0.99)
-				.style("stroke-width", "3.5px");
+				.style("stroke-width", "3px");
 			}
 
 }
@@ -604,14 +616,22 @@ if (afqb.table.splitGroups) {
 		.attr("class", "tracts means")
 		.attr("id", function(d) {return "mean" + d.key;});
 
+		meanLines.append("path")
+				.attr("class", "area")
+				.attr("d", function(d) {return afqb.plots.area(d.values); })
+				.style("opacity", 0.25);
+
 	meanLines.append("path")
 		.attr("class", "line")
 		.attr("d", function(d) {return afqb.plots.line(d.values); })
 		.style("opacity", 0.99)
-		.style("stroke-width", "3.5px");
-	// set mean colors
-	d3.select("#tractdetails").selectAll("svg").selectAll(".means")
-		.style("stroke", function (d, i) { return afqb.table.ramp(i); });
+		.style("stroke-width", "3px");
+
+		// set mean colors
+		d3.select("#tractdetails").selectAll("svg").selectAll(".means").select(".area")
+			.style("fill", function (d, i) { return afqb.table.ramp(i); });
+		d3.select("#tractdetails").selectAll("svg").selectAll(".means").select(".line")
+			.style("stroke", function (d, i) { return afqb.table.ramp(i); });
 } else{
 	// Gray meanLines for unsorted 'Plot Type' change
 	var meanLines = d3.select("#tractdetails").selectAll("svg")
@@ -624,172 +644,18 @@ if (afqb.table.splitGroups) {
 		.attr("class", "tracts means")
 		.attr("id", "mean0");
 
+		meanLines.append("path")
+			  .attr("class", "area")
+				.attr("d", function(d) {return afqb.plots.area(d); })
+				.style("opacity", 0.25);
+
 	meanLines.append("path")
 		.attr("class", "line")
 		.attr("d", function(d) {return afqb.plots.line(d); })
 		.style("opacity", 0.99)
-		.style("stroke-width", "3.5px");
+		.style("stroke-width", "3px");
 	}
-			/*d3.select("#tractdetails").selectAll("svg").selectAll(".tracts").remove();
-			// JOIN new data with old elements.
-			var trLines = d3.select("#tractdetails").selectAll("svg")
-				.data(afqb.plots.tractData).selectAll(".tracts")
-				.data(function (d) { return d.values; })
-						.enter().append("g")
-						.attr("class", "tracts")
-						.attr("id", function (d, i) {
-										return d.values[0].subjectID;
-						})
-						.on("mouseover", mouseover)
-		        .on("mouseout", mouseout)
-		        .on("click", onclick);
 
-						function mouseover() {
-				        if (!afqb.mouse.brushing) {
-				            if ($("path",this).css("stroke-width") == "1px") {
-								// uses the stroke-width of the line clicked on to
-								// determine whether to turn the line on or off
-				                d3.selectAll('#' + this.id)
-				                    .selectAll('path')
-				                    .style("opacity", 1)
-				                    .style("stroke-width", "1.1px");
-				            }
-				            if (afqb.mouse.isDown) {
-				                if ($("path",this).css("stroke-width") == "2.1px") {
-									//uses the opacity of the row for selection and deselection
-				                    d3.selectAll('#' + this.id)
-				                        .selectAll('path')
-				                        .style("opacity", afqb.controls.plotsControlBox.lineOpacity)
-				                        .style("stroke-width", "1px");
-
-				                    d3.selectAll('#' + this.id)
-				                  			.selectAll('g')
-				                				.style("opacity", 0.3);
-
-				                } else {
-				                    d3.selectAll('#' + this.id)
-				                        .selectAll('path')
-				                        .style("opacity", 1)
-				                        .style("stroke-width", "2.1px");
-
-				                    d3.selectAll('#' + this.id)
-				                        .selectAll('g')
-				                        .style("opacity", 1);
-				                }
-				            }
-				        }
-				    }
-
-				    function onclick() {
-				        if (!afqb.mouse.brushing) {
-				            if ($("path",this).css("stroke-width") == "2.1px") {
-								// uses the stroke-width of the line clicked on
-								// to determine whether to turn the line on or off
-								d3.selectAll('#' + this.id)
-									.selectAll('path')
-									.style("stroke-width", "1.1px");
-
-								d3.selectAll('#' + this.id)
-									.selectAll('g')
-									.style("opacity", 0.3);
-
-				            } else if ($("path",this).css("stroke-width") == "1.1px") {
-								d3.selectAll('#' + this.id)
-									.selectAll('path')
-									.style("opacity", 1)
-									.style("stroke-width", "2.1px");
-
-								d3.selectAll('#' + this.id)
-									.selectAll('g')
-									.style("opacity", 1);
-				            } else if ($("path",this).css("opacity") == afqb.controls.plotsControlBox.lineOpacity) {
-								d3.selectAll('#' + this.id)
-									.selectAll('path')
-									.style("opacity", 1)
-									.style("stroke-width", "2.1px");
-
-								d3.selectAll('#' + this.id)
-									.selectAll('g')
-									.style("opacity", 1);
-				            }
-				        }
-				    }
-
-				    function mouseout() {
-				        if (!afqb.mouse.brushing) {
-				            if ($("path",this).css("stroke-width") == "1.1px") {
-								// uses the stroke-width of the line clicked on to
-								// determine whether to turn the line on or off
-				                d3.selectAll('#' + this.id)
-				                    .selectAll('path')
-				                    .style("opacity", afqb.controls.plotsControlBox.lineOpacity)
-				                    .style("stroke-width", "1px");
-				            }
-				        }
-				    }
-
-				trLines.append("path")
-						.attr("class", "line")
-						.attr("d", function (d) { return afqb.plots.line(d.values); })
-						.style("opacity", afqb.controls.plotsControlBox.lineOpacity)
-						.style("stroke-width", "1px");
-
-						function idColor(element) {
-							d3.selectAll('#' + element["subjectID"])
-								.selectAll('.line')
-								.style("stroke",
-										element["group"] === null ? "black" : afqb.table.ramp(element["group"]));
-
-							d3.selectAll('#' + element["subjectID"])
-								.selectAll('.cell').select('text')
-								.style("fill",
-										element["group"] === null ? "black" : afqb.table.ramp(element["group"]));
-						}
-
-						afqb.table.subData.forEach(idColor);
-
-						// Remove old meanlines
-				d3.select("#tractdetails").selectAll("svg").selectAll(".means").remove();
-				if (afqb.table.splitGroups) {
-					 // Join new afqb.plots.tractMean data with old meanLines elements
-					 var meanLines = d3.select("#tractdetails").selectAll("svg")
-							.selectAll(".means")
-							.data(function (d) {
-								return afqb.plots.tractMean.filter(function(element) {
-									return element.key === d.key;
-								})[0].values;
-							});
-					// Enter and update. Merge entered elements and apply operations
-					meanLines.enter().append("g")
-						.attr("class", "tracts means")
-						.attr("id", function(d) {return "mean" + d.key;});
-
-					meanLines.append("path")
-						.attr("class", "line")
-						.attr("d", function(d) {return afqb.plots.line(d.values); })
-						.style("opacity", 0.99)
-						.style("stroke-width", "3.5px");
-					// set mean colors
-					 d3.select("#tractdetails").selectAll("svg").selectAll(".means")
-					   .style("stroke", function (d, i) { return afqb.table.ramp(i); });
-					  } else{
-							// Gray meanLines for unsorted 'Plot Type' change
-							var meanLines = d3.select("#tractdetails").selectAll("svg")
-								.append("g")
-								.datum(function (d) {
-									return afqb.plots.tractMean.filter(function(element) {
-										return element.key === d.key;
-									})[0].values;
-								})
-								.attr("class", "tracts means")
-								.attr("id", "mean0");
-
-							meanLines.append("path")
-								.attr("class", "line")
-								.attr("d", function(d) {return afqb.plots.line(d); })
-								.style("opacity", 0.99)
-								.style("stroke-width", "3.5px");
-						};*/
 };
 
 function updateBrush() {


### PR DESCRIPTION
I've added +/- 1 standard error of the mean shading (per @jyeatman AFQ [paper](https://doi.org/10.1371/journal.pone.0049790)). Still need to add a few things, but figured I'd get this PR rolling in case y'all want to check out the shading before the meeting tomorrow! 

Outstanding issues before merge:
- [x]  Append tract name text
- [x]  Append y axis label
- [ ] Adjust plot svg to avoid data drawn over x axis