### PR TITLE
Make headings and mouseover-highlight read from settings.json

### DIFF
--- a/afqbrowser/site/client/js/3d-brain.js
+++ b/afqbrowser/site/client/js/3d-brain.js
@@ -154,7 +154,7 @@ afqb.three.init = function () {
 		this.lhOpacity = afqb.three.settings.lHOpacity;
 		this.rhOpacity = afqb.three.settings.rHOpacity;
 		this.fiberOpacity = afqb.three.settings.fiberOpacity;
-		this.highlight = true;
+		this.highlight = afqb.three.settings.mouseoverHighlight;
 	};
 
 	afqb.three.gui = new dat.GUI({

--- a/afqbrowser/site/client/js/headings.js
+++ b/afqbrowser/site/client/js/headings.js
@@ -1,10 +1,10 @@
 // Tell jslint that afqb is a global variable
 /* global afqb */
 
-// Change the title in the html header
-document.title = afqb.global.settings.html.title || "AFQ Browser";
-
 afqb.global.updateHeadings = function () {
+    // Change the title in the html header
+    document.title = afqb.global.settings.html.title || "AFQ Browser";
+    
     // Get the h1 title
     var title = document.getElementById("title-bar");
     // If user specified a link, then create an "a" tag and fill it appropriately
@@ -37,7 +37,10 @@ afqb.global.updateHeadings = function () {
         }
         title.appendChild(subtitle);
     }
+    
+    afqb.global.settings.html.title = document.title;
 }
 
-afqb.global.updateHeadings();
-afqb.global.settings.html.title = document.title;
+afqb.global.queues.headingsQ = d3_queue.queue();
+afqb.global.queues.headingsQ.defer(afqb.global.waitForSettings);
+afqb.global.queues.headingsQ.await(afqb.global.updateHeadings);


### PR DESCRIPTION
Fixes issue pointed out by @jyeatman in #155. Does not address #155 completely but forces the headings and mouseover-highlight flags to be read from settings.json.