### PR TITLE
WIP: Use subjects.csv instead of subjects.json in sortable-table.js

### DIFF
--- a/afqbrowser/site/client/js/sortable-table.js
+++ b/afqbrowser/site/client/js/sortable-table.js
@@ -17,6 +17,17 @@ afqb.table.ramp = null;
 
 afqb.table.buildTable = function (error, useless, data) {
 	"use strict";
+	console.log(data);
+
+	data.forEach(function (d) {
+	    delete d[""];
+		Object.keys(d).forEach(function (key) {
+			d[key] = +d[key] || d[key];
+			if (d[key] === "0") {
+				d[key] = +d[key];
+			}
+		})
+	});
 
 	data.forEach(function (d) {
         if (typeof d.subjectID === 'number') {
@@ -422,5 +433,5 @@ afqb.table.tableMouseDown = function () {
 
 afqb.global.queues.subjectQ = d3_queue.queue();
 afqb.global.queues.subjectQ.defer(afqb.global.initSettings);
-afqb.global.queues.subjectQ.defer(d3.json, "data/subjects.json");
+afqb.global.queues.subjectQ.defer(d3.csv, "data/subjects.csv");
 afqb.global.queues.subjectQ.await(afqb.table.buildTable);


### PR DESCRIPTION
Resolves #180.

Remaining issues:
- [x] `subjectId` should be the first column. `sortable-table.js` preserves the order in the source data so when we were using `subjects.json` then the first column was `subjectId` but now that we are using `subjectId`, the first column has a blank heading and we discard it later. I can make the javascript always use `subjectId` as the first column and then populate the rest of the table in the order provided?
- [x] In this branch, `patient_02` had a different number of digits of precision for the score field in the json file than it did in the csv file. This leads to some ugly formatting. Do we want to impose a max number of digits to represent numerical data?