### PR TITLE
Remove dependence on faPlotLength

### DIFF
--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -56,12 +56,6 @@ afqb.plots.buildTractCheckboxes = function (error, data) {
         }
     });
 
-	// Also read the length of each line in the FA plots
-	// Determine length by filtering on the first subject and first tractID.
-	afqb.plots.faPlotLength = data.filter(function(obj) {
-		return (obj.subjectID === data[0].subjectID && obj.tractID === data[0].tractID);
-	}).length;
-
 	//insert tractname checkboxes in the tractlist panel
 	var svg = d3.select('#tractlist').selectAll(".input")
 		.data(afqb.plots.tracts).enter().append('div');


### PR DESCRIPTION
Currently, we require that each fiber in a bundle has the same length. While looking to solve #184, I realized that these should all be the same length but there's no reason that it has to be faPlotLength. So this PR removes the dependence on faPlotLength and the supporting waiter function.

This does not resolve issue #184 since it still requires each fiber in a bundle to be the same length (that length can be different for each bundle). See the discussion on #184 for that.