### PR TITLE
Fix brush extent numbers

### DIFF
--- a/afqbrowser/site/client/js/3d-brain.js
+++ b/afqbrowser/site/client/js/3d-brain.js
@@ -343,6 +343,14 @@ afqb.three.init = function (callback) {
 						afqb.plots.settings.checkboxes[myBundle.name] = myBundle.checked;
 						afqb.plots.showHideTractDetails(myBundle.checked, myBundle.name);
 						afqb.three.highlightBundle(myBundle.checked, myBundle.name);
+
+                        // Update the query string
+                        var checkboxes = {};
+                        checkboxes[myBundle.name] = myBundle.checked;
+                        afqb.global.updateQueryString(
+                            {plots: {checkboxes: checkboxes}}
+                        );
+
 						return afqb.three.renderer.render(afqb.three.scene, afqb.three.camera);
 					} else {
 						afqb.global.mouse.mouseMove = false;

--- a/afqbrowser/site/client/js/save-settings.js
+++ b/afqbrowser/site/client/js/save-settings.js
@@ -123,7 +123,7 @@ afqb.global.initSettings = function (callback) {
 };
 
 afqb.plots.restoreBrush = function () {
-	"use strict";
+    "use strict";
     Object.keys(afqb.plots.settings.brushes).forEach(function (tract) {
         if (afqb.plots.settings.brushes[tract].brushOn) {
             var targetBrush = afqb.plots.brushes.filter(function (b) {
@@ -138,11 +138,7 @@ afqb.plots.restoreBrush = function () {
 
             var formatter = d3.format(".0f");
             var ext = targetBrush.extent();
-            d3.selectAll(".brushExt").each(function(d) {
-                if (d.key.toLowerCase().replace(/\s+/g, "-") === tract) {
-                    d3.select(this).text("(" + formatter(ext[0]) + ", " + formatter(ext[1]) + ")");
-                }
-            });
+            d3.select("#brush-ext-" + tract).text("(" + formatter(ext[0]) + ", " + formatter(ext[1]) + ")");
         }
     });
 };

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -423,14 +423,14 @@ afqb.plots.ready = function (error, data) {
 		.style("fill", function(d,i){return afqb.global.d3colors[i];} )
 		.text(function(d,i) { return afqb.plots.tracts[i]; });
 
-		trPanels.append("text")
-			.attr("class", "brushExt")
-			.attr("text-anchor", "end")
-			.attr("transform", "translate("+ (afqb.plots.w + afqb.plots.m.right + 30)
-								+","+(afqb.plots.m.top+15)+")")
-			.style("stroke", function(d,i){return afqb.global.d3colors[i];} )
-			.style("fill", function(d,i){return afqb.global.d3colors[i];} )
-
+    trPanels.append("text")
+        .attr("id", function (d,i) { return "brush-ext-" + afqb.plots.tracts[i].toLowerCase().replace(/\s+/g, "-"); })
+        .attr("class", "brushExt")
+        .attr("text-anchor", "end")
+        .attr("transform", "translate("+ (afqb.plots.w + afqb.plots.m.right + 30)
+            +","+(afqb.plots.m.top+15)+")")
+        .style("stroke", function(d,i){return afqb.global.d3colors[i];} )
+        .style("fill", function(d,i){return afqb.global.d3colors[i];} )
 
 	// associate tractsline with each subject
 	var tractLines = trPanels.selectAll(".tracts")
@@ -572,6 +572,10 @@ afqb.plots.ready = function (error, data) {
 			}
 		}
 	}
+
+    d3.select("#tractdetails").selectAll("svg").each(function (d) {
+        afqb.plots.newBrush(d.key.toLowerCase().replace(/\s+/g, "-"));
+    });
 };
 
 afqb.plots.changePlots = function (error, data) {
@@ -800,20 +804,13 @@ afqb.plots.newBrush = function (name) {
 		if (targetBrush.empty()) {
 			afqb.plots.settings.brushes[targetName].brushExtent = [0, 100];
 
-			d3.selectAll(".brushExt").each(function(d) {
-                if (d.key.toLowerCase().replace(/\s+/g, "-") === targetName) {
-					d3.select(this).text("");
-				}
-			});
+			d3.select("#brush-ext-" + targetName).text("");
 		} else {
 		    afqb.plots.settings.brushes[targetName].brushExtent = targetBrush.extent();
+
             var formatter = d3.format(".0f");
             var ext = targetBrush.extent();
-            d3.selectAll(".brushExt").each(function(d) {
-                if (d.key.toLowerCase().replace(/\s+/g, "-") === targetName) {
-                    d3.select(this).text("(" + formatter(ext[0]) + ", " + formatter(ext[1]) + ")");
-                }
-            });
+            d3.select("#brush-ext-" + targetName).text("(" + formatter(ext[0]) + ", " + formatter(ext[1]) + ")");
 		}
 	}
 
@@ -838,10 +835,6 @@ afqb.plots.newBrush = function (name) {
 
 afqb.plots.updateBrush = function () {
     "use strict";
-    d3.select("#tractdetails").selectAll("svg").each(function (d) {
-        afqb.plots.newBrush(d.key.toLowerCase().replace(/\s+/g, "-"));
-    });
-
 	if (afqb.global.controls.plotsControlBox.brushTract) {
         var callBrush = function () {
             var targetName = this.parentElement.getAttribute("name");


### PR DESCRIPTION
Resolves #191 

Remove redundant calls to afqb.plots.newBrush() and give all of the brushExt elements unique ids. Select using these ids instead of class.