### PR TITLE
Fix drawRange for brushing on colorCoreGroups

### DIFF
--- a/afqbrowser/site/client/js/3d-brain.js
+++ b/afqbrowser/site/client/js/3d-brain.js
@@ -324,7 +324,9 @@ afqb.three.init = function (callback) {
             });
             colorCoreMaterial.color.setHex(afqb.global.colors[index]);
 
-            coreGeometry = new THREE.TubeBufferGeometry(coreCurve, 100, 3, 8, false);
+            var tubeSegments = 100;
+            var radiusSegments = 8;
+            coreGeometry = new THREE.TubeBufferGeometry(coreCurve, tubeSegments, 3, radiusSegments, false);
             var colorMesh = new THREE.Mesh(
                 coreGeometry, colorCoreMaterial
             );
@@ -336,6 +338,7 @@ afqb.three.init = function (callback) {
 
             // Record some useful info for later
             colorMesh.name = keyName;
+            colorMesh.geometryLength = 2 * tubeSegments * radiusSegments * 3;
             colorMesh.defaultMaterial = colorCoreMaterial;
             colorMesh.highlightMaterial = highlightCoreMaterial;
 
@@ -641,17 +644,10 @@ afqb.three.brushOn3D = function () {
 
     afqb.three.colorCoreGroup.children.forEach(function (element) {
         var lo = Math.floor(afqb.plots.settings.brushes[element.name].brushExtent[0]);
-        var hi = Math.ceil(afqb.plots.settings.brushes[element.name].brushExtent[1]) - 1;
+        var hi = Math.ceil(afqb.plots.settings.brushes[element.name].brushExtent[1]);
 
         // loIdx is the low index and count is the number of indices
-        // This is a little sloppy and sometimes the count will be too high
-        // but the visual offset should be minimal.
-        // TODO: Positions come in pairs, with all vertices except the first
-        // and last being repeated. Take this into account to make loIdx and
-        // count correct (not just good enough).
-        var position = element.geometry.attributes.position;
-        var uv = element.geometry.attributes.uv;
-        var totalLength = position.itemSize * position.count + uv.itemSize * uv.count;
+        var totalLength = element.geometryLength;
 
         // loIdx should be the nearest multiple of 3
         var loIdx = Math.floor(lo * totalLength / 100.0 / 3) * 3;

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -314,6 +314,10 @@ afqb.plots.ready = function (error, data) {
     "use strict";
 	if (error) { throw error; }
 
+    var plotKey = afqb.global.controls.plotsControlBox.plotKey;
+    afqb.plots.lastPlotKey = plotKey;
+
+
 	data.forEach(function (d) {
 		if (typeof d.subjectID === 'number') {
 			d.subjectID = "s" + afqb.global.formatKeyName(d.subjectID.toString());
@@ -322,33 +326,9 @@ afqb.plots.ready = function (error, data) {
 		}
 	});
 
-	var plotKey = afqb.global.controls.plotsControlBox.plotKey;
-
 	data = data.filter(function (d) {
 		return Boolean(d[plotKey]);
 	});
-
-    afqb.plots.yzooms[plotKey] = d3.behavior.zoom()
-        .y(afqb.plots.yScale)
-        .on("zoom", afqb.plots.zoomable ? afqb.plots.zoomAxis : null)
-        .on("zoomend",afqb.plots.zoomable ? afqb.plots.draw : null);
-
-    // If we've already stored this type of plot's zoom settings, recover them
-    if (afqb.plots.settings.zoom[plotKey]
-		&& afqb.plots.settings.zoom[plotKey].hasOwnProperty("scale")
-        && afqb.plots.settings.zoom[plotKey].hasOwnProperty("translate")) {
-        afqb.plots.yzooms[plotKey].scale(
-                parseFloat(afqb.plots.settings.zoom[plotKey].scale) || 1);
-        afqb.plots.yzooms[plotKey].translate(
-            afqb.plots.settings.zoom[plotKey].translate.map(parseFloat) || [0, 0]);
-    } else {
-        // We need to store this for later use
-        afqb.plots.settings.zoom[plotKey] = {};
-        afqb.plots.settings.zoom[plotKey].scale = afqb.plots.yzooms[plotKey].scale();
-        afqb.plots.settings.zoom[plotKey].translate = afqb.plots.yzooms[plotKey].translate();
-    }
-
-	afqb.plots.lastPlotKey = plotKey;
 
 	afqb.plots.tractData = d3.nest()
 		.key(function (d) { return d.tractID; })
@@ -397,6 +377,26 @@ afqb.plots.ready = function (error, data) {
 	}));
 
     afqb.plots.yAxis.scale(afqb.plots.yScale);
+
+    afqb.plots.yzooms[plotKey] = d3.behavior.zoom()
+        .y(afqb.plots.yScale)
+        .on("zoom", afqb.plots.zoomable ? afqb.plots.zoomAxis : null)
+        .on("zoomend",afqb.plots.zoomable ? afqb.plots.draw : null);
+
+    // If we've already stored this type of plot's zoom settings, recover them
+    if (afqb.plots.settings.zoom[plotKey]
+        && afqb.plots.settings.zoom[plotKey].hasOwnProperty("scale")
+        && afqb.plots.settings.zoom[plotKey].hasOwnProperty("translate")) {
+        afqb.plots.yzooms[plotKey].scale(
+            parseFloat(afqb.plots.settings.zoom[plotKey].scale) || 1);
+        afqb.plots.yzooms[plotKey].translate(
+            afqb.plots.settings.zoom[plotKey].translate.map(parseFloat) || [0, 0]);
+    } else {
+        // We need to store this for later use
+        afqb.plots.settings.zoom[plotKey] = {};
+        afqb.plots.settings.zoom[plotKey].scale = afqb.plots.yzooms[plotKey].scale();
+        afqb.plots.settings.zoom[plotKey].translate = afqb.plots.yzooms[plotKey].translate();
+    }
 
 	//initialize panels for each tract - and attach tract data with them
 	var trPanels = d3.select("#tractdetails").selectAll("svg").data(afqb.plots.tractData);


### PR DESCRIPTION
Previously, the very ends of the core fibers were not shown while brushing. This PR fixes that.