### PR TITLE
make idColor function a global and call it in tract-details.js

### DIFF
--- a/afqbrowser/site/client/js/sortable-table.js
+++ b/afqbrowser/site/client/js/sortable-table.js
@@ -353,7 +353,7 @@ afqb.table.refreshTable = function () {
 			afqb.table.ramp = d3.scale.linear()
 				.domain([0, numGroups-1]).range(["red", "blue"]);
 
-			var idColor = function (element) {
+			afqb.global.idColor = function (element) {
 				d3.selectAll('#' + element.subjectID)
 					.selectAll('.line')
 					.style("stroke",
@@ -365,7 +365,7 @@ afqb.table.refreshTable = function () {
 							element.group === null ? "black" : afqb.table.ramp(element.group));
 			};
 
-			afqb.table.subData.forEach(idColor); // color lines
+			afqb.table.subData.forEach(afqb.global.idColor); // color lines
 
 			d3.csv("data/nodes.csv", afqb.plots.changePlots);
 

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -975,6 +975,7 @@ afqb.plots.draw = function() {
             .style("stroke-width", "3px");
 
         // set mean colors
+        afqb.table.subData.forEach(afqb.global.idColor); // color lines
         d3.select("#tractdetails").selectAll("svg").select("#error-area").selectAll(".area")
             .style("fill", function (d, i) { return afqb.table.ramp(i); });
         d3.select("#tractdetails").selectAll("svg").select("#mean-lines").selectAll(".line")


### PR DESCRIPTION
This fixes an issue where subject lines were not colored according to their groups on page refresh.