### PR TITLE
Global toc and docstring cleanup

### DIFF
--- a/afqbrowser/site/client/js/plots.js
+++ b/afqbrowser/site/client/js/plots.js
@@ -24,7 +24,7 @@ afqb.plots.t = d3.transition().duration(750);
  * Container function which calls other plots functions
  * once nodes.csv data has been read.
  *
- * @@param error - Passed to prevent execution in case error occurs
+ * @param error - Passed to prevent execution in case error occurs
  * in preceding functions.
  * @param useless - Obligatory callback argument that we don't use in the
  * function.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,7 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['localtoc.html', 'searchbox.html']}
+html_sidebars = {'**': ['globaltoc.html', 'searchbox.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
Changes documentation sidebar to global table of contents (addresses #229). Also fixes small error in on of the plots.js docstrings.