### PR TITLE
Add title, subtitle, href prompts to afqbrowser-assemble

### DIFF
--- a/afqbrowser/browser.py
+++ b/afqbrowser/browser.py
@@ -382,14 +382,17 @@ def assemble(source, target=None, metadata=None):
         html_settings = settings.get('global').get('html')
         defaults['title'] = ('Page title', html_settings.get('title'))
         defaults['subtitle'] = ('Page subtitle', html_settings.get('subtitle'))
-        defaults['link'] = ('Title hyperlink', html_settings.get('link'))
-        defaults['sublink'] = ('Subtitle hyperlink', html_settings.get('sublink'))
+        defaults['link'] = ('Title hyperlink (including http(s)://)',
+                            html_settings.get('link'))
+        defaults['sublink'] = ('Subtitle hyperlink (including http(s)://)',
+                               html_settings.get('sublink'))
     else:
         html_settings = {}
         defaults['title'] = ('Page title', None)
         defaults['subtitle'] = ('Page subtitle', None)
-        defaults['link'] = ('Title hyperlink', None)
-        defaults['sublink'] = ('Subtitle hyperlink', None)
+        defaults['link'] = ('Title hyperlink (including http(s)://)', None)
+        defaults['sublink'] = ('Subtitle hyperlink (including http(s)://)',
+                               None)
 
     try:
         prompt = raw_input

--- a/afqbrowser/browser.py
+++ b/afqbrowser/browser.py
@@ -343,7 +343,98 @@ def copy_and_overwrite(from_path, to_path):
     shutil.copytree(from_path, to_path)
 
 
-def assemble(source, target=None, metadata=None):
+def update_settings_json(settings_path, title=None, subtitle=None,
+                         link=None, sublink=None):
+    """Update settings.json with user supplied values
+
+    settings_path : str
+    Path to the settings.json file to be updated
+
+    title : str, optional.
+    Custom page title. Default: None.
+
+    subtitle : str, optional.
+    Custom page subtitle. Default: None.
+
+    link : str, optional.
+    Custom href for page title. Default: None.
+
+    sublink : str, optional.
+    Custom href for page subtitle. Default: None.
+    """
+    # Load the settings.json
+    with open(settings_path) as fp:
+        settings = json.load(fp)
+
+    # Populate defaults from settings.json if they exist,
+    # otherwise set to empty
+    defaults = {}
+    if settings.get('global') and settings.get('global').get('html'):
+        html_settings = settings.get('global').get('html')
+    else:
+        html_settings = {}
+
+    defaults['title'] = ('Page title', html_settings.get('title'))
+    defaults['subtitle'] = ('Page subtitle', html_settings.get('subtitle'))
+    defaults['link'] = ('Title hyperlink (including http(s)://)',
+                        html_settings.get('link'))
+    defaults['sublink'] = ('Subtitle hyperlink (including http(s)://)',
+                           html_settings.get('sublink'))
+
+    # python 2 compatible user input
+    try:
+        prompt = raw_input
+    except NameError:
+        prompt = input
+
+    # Later, we'll iterate over key_list to get user input. But we don't
+    # want to ask for user input if it's supplied as an argument to this
+    # function, so if args are provided, use them as defaults, otherwise
+    # append to key_list
+    key_list = []
+    if title is not None:
+        html_settings['title'] = title
+    else:
+        key_list.append('title')
+
+    if subtitle is not None:
+        html_settings['subtitle'] = subtitle
+    else:
+        key_list.append('subtitle')
+
+    if link is not None:
+        html_settings['link'] = link
+    else:
+        key_list.append('link')
+
+    if sublink is not None:
+        html_settings['sublink'] = sublink
+    else:
+        key_list.append('sublink')
+
+    # Prompt for input
+    for key in key_list:
+        prompt_text, value = defaults[key]
+        text = '{p:s} [{d!s}]: '.format(p=prompt_text, d=value)
+        new_val = prompt(text)
+        if not new_val:
+            new_val = value
+
+        if new_val is not None:
+            html_settings[key] = new_val
+
+    # Update the settings.json dict
+    html_settings = {'global': {'html': html_settings}}
+    settings.update(html_settings)
+
+    # Write to file
+    with open(settings_path, 'w') as fp:
+        json.dump(settings, fp)
+
+
+def assemble(source, target=None, metadata=None,
+             title=None, subtitle=None,
+             link=None, sublink=None):
     """
     Spin up an instance of the AFQ-Browser with data provided as a mat file.
 
@@ -363,6 +454,18 @@ def assemble(source, target=None, metadata=None):
         provided through other. Default: read metadata from AFQ struct, or
         generate a metadata table with just a "subjectID" column (e.g., for
         TRACULA).
+
+    title : str, optional.
+        Custom page title. Default: None.
+
+    subtitle : str, optional.
+        Custom page subtitle. Default: None.
+
+    link : str, optional.
+        Custom href for page title. Default: None.
+
+    sublink : str, optional.
+        Custom href for page subtitle. Default: None.
     """
     if target is None:
         target = '.'
@@ -372,49 +475,8 @@ def assemble(source, target=None, metadata=None):
     copy_and_overwrite(data_path, site_dir)
     out_path = op.join(site_dir, 'client', 'data')
 
-    # Load the settings.json
     settings_path = op.join(site_dir, 'client', 'settings.json')
-    with open(settings_path) as fp:
-        settings = json.load(fp)
-
-    defaults = {}
-    if settings.get('global') and settings.get('global').get('html'):
-        html_settings = settings.get('global').get('html')
-        defaults['title'] = ('Page title', html_settings.get('title'))
-        defaults['subtitle'] = ('Page subtitle', html_settings.get('subtitle'))
-        defaults['link'] = ('Title hyperlink (including http(s)://)',
-                            html_settings.get('link'))
-        defaults['sublink'] = ('Subtitle hyperlink (including http(s)://)',
-                               html_settings.get('sublink'))
-    else:
-        html_settings = {}
-        defaults['title'] = ('Page title', None)
-        defaults['subtitle'] = ('Page subtitle', None)
-        defaults['link'] = ('Title hyperlink (including http(s)://)', None)
-        defaults['sublink'] = ('Subtitle hyperlink (including http(s)://)',
-                               None)
-
-    try:
-        prompt = raw_input
-    except NameError:
-        prompt = input
-
-    key_list = ['title', 'subtitle', 'link', 'sublink']
-    for key in key_list:
-        prompt_text, value = defaults[key]
-        text = '{p:s} [{d!s}]: '.format(p=prompt_text, d=value)
-        new_val = prompt(text)
-        if not new_val:
-            new_val = value
-
-        if new_val is not None:
-            html_settings[key] = new_val
-
-    html_settings = {'global': {'html': html_settings}}
-    settings.update(html_settings)
-
-    with open(settings_path, 'w') as fp:
-        json.dump(settings, fp)
+    update_settings_json(settings_path, title, subtitle, link, sublink)
 
     if source.endswith('.mat'):
         # We have an AFQ-generated mat-file on our hands:

--- a/afqbrowser/site/client/css/style.css
+++ b/afqbrowser/site/client/css/style.css
@@ -27,6 +27,16 @@ h1 {
   text-align: center;
 }
 
+#title-bar-subtitle {
+  font-size: 75%;
+}
+
+#title-bar-separator {
+  padding-left: 10px;
+  padding-right: 10px;
+  visibility: hidden;
+}
+
 h2 {
   text-align: center;
   text-transform: uppercase;

--- a/afqbrowser/site/client/index.html
+++ b/afqbrowser/site/client/index.html
@@ -34,7 +34,9 @@
 <div class="page-container">
   <header id="header">
     <h1 id="title-bar" style="color:white;">
-      AFQ Browser
+      <span id="title-bar-title">AFQ Browser</span>
+      <span id="title-bar-separator"> | </span>
+      <span id="title-bar-subtitle"></span>
     </h1>
     <a id="launch-binder" href="#" target="_blank" class="binderBtn" title="Publish to GitHub to enable Binder integration">
       <img src="https://mybinder.org/badge.svg" />

--- a/afqbrowser/site/client/js/headings.js
+++ b/afqbrowser/site/client/js/headings.js
@@ -9,7 +9,7 @@ afqb.global.updateHeadings = function () {
     document.title = afqb.global.settings.html.title || "AFQ Browser";
     
     // Get the h1 title
-    var title = document.getElementById("title-bar");
+    var title = document.getElementById("title-bar-title");
     // If user specified a link, then create an "a" tag and fill it appropriately
     // else, just put the text
     if (afqb.global.settings.html.link) {
@@ -24,21 +24,17 @@ afqb.global.updateHeadings = function () {
 
     if (afqb.global.settings.html.subtitle) {
         // If the user specified a subtitle then add a span tag to the title-bar 
-        var subtitle = document.createElement("span");
-        subtitle.id = "title-bar-subtitle"; //Assign span id
-        subtitle.setAttribute("style", "font-size: 75%;"); //Set span style
+        var subtitle = $('#title-bar-subtitle');
         if (afqb.global.settings.html.sublink) {
             var a = document.createElement("a");
             a.href = afqb.global.settings.html.sublink;
             a.innerHTML = afqb.global.settings.html.subtitle || "";
-            title.innerHTML += " | ";
-            subtitle.innerHTML = "";
-            subtitle.appendChild(a);
+            subtitle.html("");
+            subtitle.append(a);
         } else {
-            title.innerHTML += " | ";
-            subtitle.innerHTML = afqb.global.settings.html.subtitle || "";
+            subtitle.html(afqb.global.settings.html.subtitle || "");
         }
-        title.appendChild(subtitle);
+        $('#title-bar-separator').css("visibility", "visible");
     }
     
     afqb.global.settings.html.title = document.title;

--- a/afqbrowser/tests/test_browser.py
+++ b/afqbrowser/tests/test_browser.py
@@ -10,7 +10,7 @@ def test_assemble():
     data_path = op.join(afqb.__path__[0], 'site')
     tdir = tempfile.mkdtemp()
     afqb.assemble(op.join(data_path, 'client', 'data', 'afq.mat'),
-                  target=tdir)
+                  target=tdir, title='', subtitle='', link='', sublink='')
 
     # Check for regression against know results:
     out_data = op.join(tdir, 'AFQ-browser', 'client', 'data')

--- a/bin/afqbrowser-assemble
+++ b/bin/afqbrowser-assemble
@@ -44,5 +44,5 @@ parser.add_argument(
 args = parser.parse_args()
 
 afqb.assemble(args.source, target=args.target, metadata=args.metadata,
-              title=args.title, subtitle=args.subtitle,
-              link=args.link, sublink=args.sublink)
+              title=args.page_title, subtitle=args.page_subtitle,
+              link=args.page_title_link, sublink=args.page_subtitle_link)

--- a/bin/afqbrowser-assemble
+++ b/bin/afqbrowser-assemble
@@ -21,6 +21,28 @@ parser.add_argument(
         help="Path to subject metadata csv file",
         default=None)
 
+parser.add_argument(
+        "--page-title", metavar="title",
+        help="Page title",
+        default=None)
+
+parser.add_argument(
+        "--page-subtitle", metavar="subtitle",
+        help="Page subtitle",
+        default=None)
+
+parser.add_argument(
+        "--page-title-link", metavar="link",
+        help="Title hyperlink (including http(s)://)",
+        default=None)
+
+parser.add_argument(
+        "--page-subtitle-link", metavar="sublink",
+        help="Subtitle hyperlink (including http(s)://)",
+        default=None)
+
 args = parser.parse_args()
 
-afqb.assemble(args.source, target=args.target, metadata=args.metadata)
+afqb.assemble(args.source, target=args.target, metadata=args.metadata,
+              title=args.title, subtitle=args.subtitle,
+              link=args.link, sublink=args.sublink)

--- a/bin/afqbrowser-assemble
+++ b/bin/afqbrowser-assemble
@@ -3,8 +3,9 @@
 from argparse import ArgumentParser
 import afqbrowser as afqb
 
-description = """Assembele an instance of the AFQ-Browser with
-        data provided as a mat file"""
+description = """Assembles an instance of the AFQ-Browser with data provided as
+a mat file."""
+
 parser = ArgumentParser(description=description)
 
 parser.add_argument(

--- a/bin/afqbrowser-publish
+++ b/bin/afqbrowser-publish
@@ -3,13 +3,13 @@
 from argparse import ArgumentParser
 import afqbrowser.gh_pages as gh
 
-description = """Publish an AFQ-Browser site as a GitHub webpage"""
+description = """Publishes an AFQ-Browser site as a GitHub webpage."""
 parser = ArgumentParser(description=description)
 
 parser.add_argument("target",
                     type=str,
                     metavar="target",
-                    help="path to location containing the browser instance")
+                    help="Path to location containing the browser instance")
 
 parser.add_argument("reponame",
                     type=str,

--- a/bin/afqbrowser-run
+++ b/bin/afqbrowser-run
@@ -3,14 +3,13 @@
 from argparse import ArgumentParser
 import afqbrowser as afqb
 
-description = """Serve the AFQ-Browser locally given a file structure location
-        and a specified port."""
+description = """Runs the AFQ-Browser site locally given a file-system location and a specified port."""
 parser = ArgumentParser(description=description)
 
 parser.add_argument("-t", "--target", metavar="target",
-        help="path to location containing the browser instance", default=None)
+        help="Path to location containing the browser instance", default=None)
 parser.add_argument("-p", "--port", type=int, metavar="port",
-        help="port number", default=8080)
+        help="Port number", default=8080)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
Addresses #232. `afqbrowser-assemble` now prompts the user for their desired title, subtitle, and hrefs.