### PR TITLE
Allow using an org instead of the user-name as the github website.

### DIFF
--- a/afqbrowser/gh_pages.py
+++ b/afqbrowser/gh_pages.py
@@ -106,8 +106,8 @@ def upload(target, repo_name, uname=None, upass=None, token=None, org=None):
                            index_col=0)
     shape = manifest.shape
     manifest = manifest.append(pd.DataFrame(data=dict(
-                username=[uname if org is None else org],
-                repository_name=[repo_name])))
+        username=[uname if org is None else org],
+        repository_name=[repo_name])))
 
     # Deduplicate -- if this site was already uploaded, we're done!
     manifest = manifest.drop_duplicates()

--- a/bin/afqbrowser-publish
+++ b/bin/afqbrowser-publish
@@ -23,5 +23,5 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-url = gh.upload(args.target, args.reponame, args.org)
+url = gh.upload(args.target, args.reponame, org=args.org)
 print("Website available on: %s" % url)

--- a/bin/afqbrowser-publish
+++ b/bin/afqbrowser-publish
@@ -16,7 +16,12 @@ parser.add_argument("reponame",
                     metavar="reponame",
                     help="The name of the GitHub repo for the website")
 
+parser.add_argument(
+        "-o", "--org", metavar="org",
+        help="The name of a GitHub org for the website",
+        default=None)
+
 args = parser.parse_args()
 
-url = gh.upload(args.target, args.reponame)
+url = gh.upload(args.target, args.reponame, args.org)
 print("Website available on: %s" % url)


### PR DESCRIPTION
Right now, websites can only be published to URLs of the form: 

https://user.github.io/website

I would like to make it possible for people to publish to GitHub orgs they belong to: 

https://org.github.io/website. 
