### PR TITLE
fix: changed tooltip margins to em not pix for different resolutions

### DIFF
--- a/afqbrowser/site/client/css/style.css
+++ b/afqbrowser/site/client/css/style.css
@@ -635,17 +635,23 @@ div.tooltip {
     pointer-events: none;
 }
 
+
+
 .titleTip {
-  margin: 2px;
+  margin: .2em;
+}
+
+.titleTip hr {
+  margin: 0.5em;
 }
 
 .zTip {
-  margin-bottom: 2px;
+  margin-bottom: .2em;
 }
 
 .disabled {
   cursor: not-allowed;
-  
+
   opacity: 0.5;
 }
 


### PR DESCRIPTION
addressing https://github.com/yeatmanlab/AFQ-Browser/issues/246 -- converted pixels to em for different screen resolutions