### PR TITLE
Fixes the binder url.

### DIFF
--- a/afqbrowser/site/client/js/save-settings.js
+++ b/afqbrowser/site/client/js/save-settings.js
@@ -236,7 +236,7 @@ var setupBinderURL = function () {
     var repo = uri.directory();
 
     // Construct binder URL and set the button's href
-    var binderUrl = 'https://mybinder.org/v2/gh/' + user + '/' + repo + '/gh-pages?filepath=index.ipynb';
+    var binderUrl = 'https://mybinder.org/v2/gh/' + user + repo + '/gh-pages?filepath=index.ipynb';
      $("#launch-binder").attr("href", binderUrl);
     return false;
 }


### PR DESCRIPTION
This used to work, but current version of binder is less tolerant of
duplication of slashes.

This means that our current demo site doesn't redirect to binder properly. Will also patch that separately. 